### PR TITLE
Modify width of Postcode

### DIFF
--- a/src/DaumPostcode.jsx
+++ b/src/DaumPostcode.jsx
@@ -1,174 +1,187 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
-const defaultErrorMessage = (<p>현재 Daum 우편번호 서비스를 이용할 수 없습니다. 잠시 후 다시 시도해주세요.</p>);
+const defaultErrorMessage = (
+    <p>
+        현재 Daum 우편번호 서비스를 이용할 수 없습니다. 잠시 후 다시
+        시도해주세요.
+    </p>
+);
 
 class DaumPostcode extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      display: 'block',
-      width: this.props.width,
-      height: this.props.height,
-      error: false,
+    constructor(props) {
+        super(props);
+        this.state = {
+            display: "block",
+            width: this.props.width,
+            height: this.props.height,
+            error: false,
+        };
+    }
+
+    componentDidMount() {
+        const scriptId = "daum_postcode_script";
+        const isExist = !!document.getElementById(scriptId);
+
+        if (!isExist) {
+            const script = document.createElement("script");
+            script.src = this.props.scriptUrl;
+            script.onload = () => this.initiate(this);
+            script.onerror = (error) => this.handleError(error);
+            script.id = scriptId;
+            document.body.appendChild(script);
+        } else this.initiate(this);
+    }
+
+    initiate = (comp) => {
+        window.daum.postcode.load(() => {
+            const Postcode = new window.daum.Postcode({
+                oncomplete: function oncomplete(data) {
+                    comp.props.onComplete(data);
+                    if (comp.props.autoClose)
+                        comp.setState({ display: "none" });
+                },
+                onsearch: comp.props.onSearch,
+                onresize: function onresize(size) {
+                    if (comp.props.autoResize)
+                        comp.setState({ height: size.height });
+                },
+                alwaysShowEngAddr: comp.props.alwaysShowEngAddr,
+                animation: comp.props.animation,
+                autoMapping: comp.props.autoMapping,
+                autoResize: comp.props.autoResize,
+                height: comp.props.height,
+                hideEngBtn: comp.props.hideEngBtn,
+                hideMapBtn: comp.props.hideMapBtn,
+                maxSuggestItems: comp.props.maxSuggestItems,
+                pleaseReadGuide: comp.props.pleaseReadGuide,
+                pleaseReadGuideTimer: comp.props.pleaseReadGuideTimer,
+                shorthand: comp.props.shorthand,
+                showMoreHName: comp.props.showMoreHName,
+                submitMode: comp.props.submitMode,
+                theme: comp.props.theme,
+                useSuggest: comp.props.useSuggest,
+                width: "100%",
+                focusInput: comp.props.focusInput,
+                focusContent: comp.props.focusContent,
+            });
+
+            Postcode.embed(this.wrap, {
+                q: this.props.defaultQuery,
+                autoClose: this.props.autoClose,
+            });
+        });
     };
-  }
 
-  componentDidMount() {
-    const scriptId = 'daum_postcode_script';
-    const isExist = !!document.getElementById(scriptId);
+    handleError = (error) => {
+        error.target.remove();
+        this.setState({ error: true });
+    };
 
-    if (!isExist) {
-      const script = document.createElement('script');
-      script.src = this.props.scriptUrl;
-      script.onload = () => this.initiate(this);
-      script.onerror = error => this.handleError(error);
-      script.id = scriptId;
-      document.body.appendChild(script);
-    } else this.initiate(this);
-  }
+    render() {
+        const {
+            style,
+            onComplete,
+            onSearch,
+            alwaysShowEngAddr,
+            animation,
+            autoClose,
+            autoMapping,
+            autoResize,
+            defaultQuery,
+            errorMessage,
+            height,
+            hideEngBtn,
+            hideMapBtn,
+            maxSuggestItems,
+            pleaseReadGuide,
+            pleaseReadGuideTimer,
+            scriptUrl,
+            shorthand,
+            showMoreHName,
+            submitMode,
+            theme,
+            useSuggest,
+            width,
+            zonecodeOnly,
+            focusInput,
+            focusContent,
+            ...rest
+        } = this.props;
 
-  initiate = (comp) => {
-    window.daum.postcode.load(() => {
-      const Postcode = new window.daum.Postcode({
-        oncomplete: function oncomplete(data) {
-          comp.props.onComplete(data);
-          if (comp.props.autoClose) comp.setState({ display: 'none' });
-        },
-        onsearch: comp.props.onSearch,
-        onresize: function onresize(size) {
-          if (comp.props.autoResize) comp.setState({ height: size.height });
-        },
-        alwaysShowEngAddr: comp.props.alwaysShowEngAddr,
-        animation: comp.props.animation,
-        autoMapping: comp.props.autoMapping,
-        autoResize: comp.props.autoResize,
-        height: comp.props.height,
-        hideEngBtn: comp.props.hideEngBtn,
-        hideMapBtn: comp.props.hideMapBtn,
-        maxSuggestItems: comp.props.maxSuggestItems,
-        pleaseReadGuide: comp.props.pleaseReadGuide,
-        pleaseReadGuideTimer: comp.props.pleaseReadGuideTimer,
-        shorthand: comp.props.shorthand,
-        showMoreHName: comp.props.showMoreHName,
-        submitMode: comp.props.submitMode,
-        theme: comp.props.theme,
-        useSuggest: comp.props.useSuggest,
-        width: comp.props.width,
-        focusInput: comp.props.focusInput,
-        focusContent: comp.props.focusContent,
-      });
-
-      Postcode.embed(this.wrap, { q: this.props.defaultQuery, autoClose: this.props.autoClose });
-    });
-  };
-
-  handleError = (error) => {
-    error.target.remove();
-    this.setState({ error: true });
-  };
-
-  render() {
-    const {
-      style,
-      onComplete,
-      onSearch,
-      alwaysShowEngAddr,
-      animation,
-      autoClose,
-      autoMapping,
-      autoResize,
-      defaultQuery,
-      errorMessage,
-      height,
-      hideEngBtn,
-      hideMapBtn,
-      maxSuggestItems,
-      pleaseReadGuide,
-      pleaseReadGuideTimer,
-      scriptUrl,
-      shorthand,
-      showMoreHName,
-      submitMode,
-      theme,
-      useSuggest,
-      width,
-      zonecodeOnly,
-      focusInput,
-      focusContent,
-      ...rest
-    } = this.props;
-
-    return (
-      <div
-        ref={(div) => { this.wrap = div; }}
-        style={{
-          width: this.state.width,
-          height: this.state.height,
-          display: this.state.display,
-          ...style,
-        }}
-        {...rest}
-      >
-        {this.state.error && this.props.errorMessage}
-      </div>
-    );
-  }
+        return (
+            <div
+                ref={(div) => {
+                    this.wrap = div;
+                }}
+                style={{
+                    width: this.state.width,
+                    height: this.state.height,
+                    display: this.state.display,
+                    ...style,
+                }}
+                {...rest}
+            >
+                {this.state.error && this.props.errorMessage}
+            </div>
+        );
+    }
 }
 
 DaumPostcode.propTypes = {
-  onComplete: PropTypes.func.isRequired,
-  onSearch: PropTypes.func,
-  alwaysShowEngAddr: PropTypes.bool,
-  animation: PropTypes.bool,
-  autoClose: PropTypes.bool,
-  autoMapping: PropTypes.bool,
-  autoResize: PropTypes.bool,
-  defaultQuery: PropTypes.string,
-  errorMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  hideEngBtn: PropTypes.bool,
-  hideMapBtn: PropTypes.bool,
-  maxSuggestItems: PropTypes.number,
-  pleaseReadGuide: PropTypes.number,
-  pleaseReadGuideTimer: PropTypes.number,
-  scriptUrl: PropTypes.string,
-  shorthand: PropTypes.bool,
-  showMoreHName: PropTypes.bool,
-  style: PropTypes.object,
-  submitMode: PropTypes.bool,
-  theme: PropTypes.object,
-  useSuggest: PropTypes.bool,
-  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  focusInput: PropTypes.bool,
-  focusContent: PropTypes.bool,
+    onComplete: PropTypes.func.isRequired,
+    onSearch: PropTypes.func,
+    alwaysShowEngAddr: PropTypes.bool,
+    animation: PropTypes.bool,
+    autoClose: PropTypes.bool,
+    autoMapping: PropTypes.bool,
+    autoResize: PropTypes.bool,
+    defaultQuery: PropTypes.string,
+    errorMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    hideEngBtn: PropTypes.bool,
+    hideMapBtn: PropTypes.bool,
+    maxSuggestItems: PropTypes.number,
+    pleaseReadGuide: PropTypes.number,
+    pleaseReadGuideTimer: PropTypes.number,
+    scriptUrl: PropTypes.string,
+    shorthand: PropTypes.bool,
+    showMoreHName: PropTypes.bool,
+    style: PropTypes.object,
+    submitMode: PropTypes.bool,
+    theme: PropTypes.object,
+    useSuggest: PropTypes.bool,
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    focusInput: PropTypes.bool,
+    focusContent: PropTypes.bool,
 };
 
 DaumPostcode.defaultProps = {
-  onSearch: undefined,
-  alwaysShowEngAddr: false,
-  animation: false,
-  autoClose: false,
-  autoMapping: true,
-  autoResize: false,
-  defaultQuery: null,
-  errorMessage: defaultErrorMessage,
-  height: 400,
-  hideEngBtn: false,
-  hideMapBtn: false,
-  maxSuggestItems: 10,
-  pleaseReadGuide: 0,
-  pleaseReadGuideTimer: 1.5,
-  scriptUrl: 'https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js',
-  shorthand: true,
-  showMoreHName: false,
-  style: null,
-  submitMode: true,
-  theme: null,
-  useSuggest: true,
-  width: '100%',
-  focusInput: true,
-  focusContent: true,
+    onSearch: undefined,
+    alwaysShowEngAddr: false,
+    animation: false,
+    autoClose: false,
+    autoMapping: true,
+    autoResize: false,
+    defaultQuery: null,
+    errorMessage: defaultErrorMessage,
+    height: 400,
+    hideEngBtn: false,
+    hideMapBtn: false,
+    maxSuggestItems: 10,
+    pleaseReadGuide: 0,
+    pleaseReadGuideTimer: 1.5,
+    scriptUrl:
+        "https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js",
+    shorthand: true,
+    showMoreHName: false,
+    style: null,
+    submitMode: true,
+    theme: null,
+    useSuggest: true,
+    width: "100%",
+    focusInput: true,
+    focusContent: true,
 };
 
 export default DaumPostcode;


### PR DESCRIPTION
안녕하세요. 저는 신생 스타트업에서 일하고 있는 새내기 개발자 이지은입니다.
먼저, react-daum-postcode 를 만들어주셔서 대단히 감사합니다.
덕분에 react로 웹을 개발하면서 주소를 검색하는 코드를 구현하는데에 있어 굉장히 편리함을 느꼈습니다.

다름이 아니라, 제가 라이브러리를 사용하는데에 있어 발견한 점이 있어 pull request를 생성했습니다.
다름이 아니라, width를 정확한 px가 아닌 %로 주니 
<img width="430" alt="스크린샷 2021-02-12 14 02 38" src="https://user-images.githubusercontent.com/60080273/107732140-f8861680-6d3a-11eb-8016-61a1fc9df3f1.png">
다음과 같이 화면이 나타났습니다.
그래서 개발자 도구로 확인을 해보니 DaumPostcode.jsx 에 있는 initiate 안에 있는 Postcode 상수에서 width를 수정해주면 문제가 해결됐습니다. 원래처럼 px 값을 줄 경우에도 문제 없이 잘 작동했습니다.

설날인데 새해 복 많이 받으세요, 감사합니다!
이지은(ee2e@naver.com) 드림
