### PR TITLE
Modify to work well even if width is specified as %.

### DIFF
--- a/lib/DaumPostcode.js
+++ b/lib/DaumPostcode.js
@@ -1,1 +1,309 @@
-'use strict';var _extends=Object.assign||function(a){for(var b,c=1;c<arguments.length;c++)for(var d in b=arguments[c],b)Object.prototype.hasOwnProperty.call(b,d)&&(a[d]=b[d]);return a},_createClass=function(){function a(a,b){for(var c,d=0;d<b.length;d++)c=b[d],c.enumerable=c.enumerable||!1,c.configurable=!0,'value'in c&&(c.writable=!0),Object.defineProperty(a,c.key,c)}return function(b,c,d){return c&&a(b.prototype,c),d&&a(b,d),b}}(),_react=require('react'),_react2=_interopRequireDefault(_react),_propTypes=require('prop-types'),_propTypes2=_interopRequireDefault(_propTypes);Object.defineProperty(exports,'__esModule',{value:!0});function _interopRequireDefault(a){return a&&a.__esModule?a:{default:a}}function _objectWithoutProperties(a,b){var c={};for(var d in a)!(0<=b.indexOf(d))&&Object.prototype.hasOwnProperty.call(a,d)&&(c[d]=a[d]);return c}function _classCallCheck(a,b){if(!(a instanceof b))throw new TypeError('Cannot call a class as a function')}function _possibleConstructorReturn(a,b){if(!a)throw new ReferenceError('this hasn\'t been initialised - super() hasn\'t been called');return b&&('object'==typeof b||'function'==typeof b)?b:a}function _inherits(a,b){if('function'!=typeof b&&null!==b)throw new TypeError('Super expression must either be null or a function, not '+typeof b);a.prototype=Object.create(b&&b.prototype,{constructor:{value:a,enumerable:!1,writable:!0,configurable:!0}}),b&&(Object.setPrototypeOf?Object.setPrototypeOf(a,b):a.__proto__=b)}var defaultErrorMessage=_react2.default.createElement('p',null,'\uD604\uC7AC Daum \uC6B0\uD3B8\uBC88\uD638 \uC11C\uBE44\uC2A4\uB97C \uC774\uC6A9\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4. \uC7A0\uC2DC \uD6C4 \uB2E4\uC2DC \uC2DC\uB3C4\uD574\uC8FC\uC138\uC694.'),DaumPostcode=function(a){function b(a){_classCallCheck(this,b);var c=_possibleConstructorReturn(this,(b.__proto__||Object.getPrototypeOf(b)).call(this,a));return c.state={display:'block',width:c.props.width,height:c.props.height,error:!1},c.initiate=function(a){window.daum.postcode.load(function(){var b=new window.daum.Postcode({oncomplete:function(b){a.props.onComplete(b),a.props.autoClose&&a.setState({display:'none'})},onsearch:a.props.onSearch,onresize:function(b){a.props.autoResize&&a.setState({height:b.height})},alwaysShowEngAddr:a.props.alwaysShowEngAddr,animation:a.props.animation,autoMapping:a.props.autoMapping,autoResize:a.props.autoResize,height:a.props.height,hideEngBtn:a.props.hideEngBtn,hideMapBtn:a.props.hideMapBtn,maxSuggestItems:a.props.maxSuggestItems,pleaseReadGuide:a.props.pleaseReadGuide,pleaseReadGuideTimer:a.props.pleaseReadGuideTimer,shorthand:a.props.shorthand,showMoreHName:a.props.showMoreHName,submitMode:a.props.submitMode,theme:a.props.theme,useSuggest:a.props.useSuggest,width:a.props.width,focusInput:a.props.focusInput,focusContent:a.props.focusContent});b.embed(c.wrap,{q:c.props.defaultQuery,autoClose:c.props.autoClose})})},c.handleError=function(a){a.target.remove(),c.setState({error:!0})},c.state={display:'block',width:c.props.width,height:c.props.height,error:!1},c}return _inherits(b,a),_createClass(b,[{key:'componentDidMount',value:function componentDidMount(){var a=this,b='daum_postcode_script',c=!!document.getElementById(b);if(!c){var d=document.createElement('script');d.src=this.props.scriptUrl,d.onload=function(){return a.initiate(a)},d.onerror=function(b){return a.handleError(b)},d.id=b,document.body.appendChild(d)}else this.initiate(this)}},{key:'render',value:function render(){var a=this,b=this.props,c=b.style,d=b.onComplete,e=b.onSearch,f=b.alwaysShowEngAddr,g=b.animation,h=b.autoClose,i=b.autoMapping,j=b.autoResize,k=b.defaultQuery,l=b.errorMessage,m=b.height,n=b.hideEngBtn,o=b.hideMapBtn,p=b.maxSuggestItems,q=b.pleaseReadGuide,r=b.pleaseReadGuideTimer,s=b.scriptUrl,t=b.shorthand,u=b.showMoreHName,v=b.submitMode,w=b.theme,x=b.useSuggest,y=b.width,z=b.zonecodeOnly,A=b.focusInput,B=b.focusContent,C=_objectWithoutProperties(b,['style','onComplete','onSearch','alwaysShowEngAddr','animation','autoClose','autoMapping','autoResize','defaultQuery','errorMessage','height','hideEngBtn','hideMapBtn','maxSuggestItems','pleaseReadGuide','pleaseReadGuideTimer','scriptUrl','shorthand','showMoreHName','submitMode','theme','useSuggest','width','zonecodeOnly','focusInput','focusContent']);return _react2.default.createElement('div',_extends({ref:function ref(b){a.wrap=b},style:_extends({width:this.state.width,height:this.state.height,display:this.state.display},c)},C),this.state.error&&this.props.errorMessage)}}]),b}(_react2.default.Component);DaumPostcode.propTypes={onComplete:_propTypes2.default.func.isRequired,onSearch:_propTypes2.default.func,alwaysShowEngAddr:_propTypes2.default.bool,animation:_propTypes2.default.bool,autoClose:_propTypes2.default.bool,autoMapping:_propTypes2.default.bool,autoResize:_propTypes2.default.bool,defaultQuery:_propTypes2.default.string,errorMessage:_propTypes2.default.oneOfType([_propTypes2.default.string,_propTypes2.default.element]),height:_propTypes2.default.oneOfType([_propTypes2.default.number,_propTypes2.default.string]),hideEngBtn:_propTypes2.default.bool,hideMapBtn:_propTypes2.default.bool,maxSuggestItems:_propTypes2.default.number,pleaseReadGuide:_propTypes2.default.number,pleaseReadGuideTimer:_propTypes2.default.number,scriptUrl:_propTypes2.default.string,shorthand:_propTypes2.default.bool,showMoreHName:_propTypes2.default.bool,style:_propTypes2.default.object,submitMode:_propTypes2.default.bool,theme:_propTypes2.default.object,useSuggest:_propTypes2.default.bool,width:_propTypes2.default.oneOfType([_propTypes2.default.number,_propTypes2.default.string]),focusInput:_propTypes2.default.bool,focusContent:_propTypes2.default.bool},DaumPostcode.defaultProps={onSearch:void 0,alwaysShowEngAddr:!1,animation:!1,autoClose:!1,autoMapping:!0,autoResize:!1,defaultQuery:null,errorMessage:defaultErrorMessage,height:400,hideEngBtn:!1,hideMapBtn:!1,maxSuggestItems:10,pleaseReadGuide:0,pleaseReadGuideTimer:1.5,scriptUrl:'https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js',shorthand:!0,showMoreHName:!1,style:null,submitMode:!0,theme:null,useSuggest:!0,width:'100%',focusInput:!0,focusContent:!0},exports.default=DaumPostcode;
+"use strict";
+var _extends =
+        Object.assign ||
+        function (a) {
+            for (var b, c = 1; c < arguments.length; c++)
+                for (var d in ((b = arguments[c]), b))
+                    Object.prototype.hasOwnProperty.call(b, d) && (a[d] = b[d]);
+            return a;
+        },
+    _createClass = (function () {
+        function a(a, b) {
+            for (var c, d = 0; d < b.length; d++)
+                (c = b[d]),
+                    (c.enumerable = c.enumerable || !1),
+                    (c.configurable = !0),
+                    "value" in c && (c.writable = !0),
+                    Object.defineProperty(a, c.key, c);
+        }
+        return function (b, c, d) {
+            return c && a(b.prototype, c), d && a(b, d), b;
+        };
+    })(),
+    _react = require("react"),
+    _react2 = _interopRequireDefault(_react),
+    _propTypes = require("prop-types"),
+    _propTypes2 = _interopRequireDefault(_propTypes);
+Object.defineProperty(exports, "__esModule", { value: !0 });
+function _interopRequireDefault(a) {
+    return a && a.__esModule ? a : { default: a };
+}
+function _objectWithoutProperties(a, b) {
+    var c = {};
+    for (var d in a)
+        !(0 <= b.indexOf(d)) &&
+            Object.prototype.hasOwnProperty.call(a, d) &&
+            (c[d] = a[d]);
+    return c;
+}
+function _classCallCheck(a, b) {
+    if (!(a instanceof b))
+        throw new TypeError("Cannot call a class as a function");
+}
+function _possibleConstructorReturn(a, b) {
+    if (!a)
+        throw new ReferenceError(
+            "this hasn't been initialised - super() hasn't been called"
+        );
+    return b && ("object" == typeof b || "function" == typeof b) ? b : a;
+}
+function _inherits(a, b) {
+    if ("function" != typeof b && null !== b)
+        throw new TypeError(
+            "Super expression must either be null or a function, not " +
+                typeof b
+        );
+    (a.prototype = Object.create(b && b.prototype, {
+        constructor: {
+            value: a,
+            enumerable: !1,
+            writable: !0,
+            configurable: !0,
+        },
+    })),
+        b &&
+            (Object.setPrototypeOf
+                ? Object.setPrototypeOf(a, b)
+                : (a.__proto__ = b));
+}
+var defaultErrorMessage = _react2.default.createElement(
+        "p",
+        null,
+        "\uD604\uC7AC Daum \uC6B0\uD3B8\uBC88\uD638 \uC11C\uBE44\uC2A4\uB97C \uC774\uC6A9\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4. \uC7A0\uC2DC \uD6C4 \uB2E4\uC2DC \uC2DC\uB3C4\uD574\uC8FC\uC138\uC694."
+    ),
+    DaumPostcode = (function (a) {
+        function b(a) {
+            _classCallCheck(this, b);
+            var c = _possibleConstructorReturn(
+                this,
+                (b.__proto__ || Object.getPrototypeOf(b)).call(this, a)
+            );
+            return (
+                (c.state = {
+                    display: "block",
+                    width: c.props.width,
+                    height: c.props.height,
+                    error: !1,
+                }),
+                (c.initiate = function (a) {
+                    window.daum.postcode.load(function () {
+                        var b = new window.daum.Postcode({
+                            oncomplete: function (b) {
+                                a.props.onComplete(b),
+                                    a.props.autoClose &&
+                                        a.setState({ display: "none" });
+                            },
+                            onsearch: a.props.onSearch,
+                            onresize: function (b) {
+                                a.props.autoResize &&
+                                    a.setState({ height: b.height });
+                            },
+                            alwaysShowEngAddr: a.props.alwaysShowEngAddr,
+                            animation: a.props.animation,
+                            autoMapping: a.props.autoMapping,
+                            autoResize: a.props.autoResize,
+                            height: a.props.height,
+                            hideEngBtn: a.props.hideEngBtn,
+                            hideMapBtn: a.props.hideMapBtn,
+                            maxSuggestItems: a.props.maxSuggestItems,
+                            pleaseReadGuide: a.props.pleaseReadGuide,
+                            pleaseReadGuideTimer: a.props.pleaseReadGuideTimer,
+                            shorthand: a.props.shorthand,
+                            showMoreHName: a.props.showMoreHName,
+                            submitMode: a.props.submitMode,
+                            theme: a.props.theme,
+                            useSuggest: a.props.useSuggest,
+                            width: "100%",
+                            focusInput: a.props.focusInput,
+                            focusContent: a.props.focusContent,
+                        });
+                        b.embed(c.wrap, {
+                            q: c.props.defaultQuery,
+                            autoClose: c.props.autoClose,
+                        });
+                    });
+                }),
+                (c.handleError = function (a) {
+                    a.target.remove(), c.setState({ error: !0 });
+                }),
+                (c.state = {
+                    display: "block",
+                    width: c.props.width,
+                    height: c.props.height,
+                    error: !1,
+                }),
+                c
+            );
+        }
+        return (
+            _inherits(b, a),
+            _createClass(b, [
+                {
+                    key: "componentDidMount",
+                    value: function componentDidMount() {
+                        var a = this,
+                            b = "daum_postcode_script",
+                            c = !!document.getElementById(b);
+                        if (!c) {
+                            var d = document.createElement("script");
+                            (d.src = this.props.scriptUrl),
+                                (d.onload = function () {
+                                    return a.initiate(a);
+                                }),
+                                (d.onerror = function (b) {
+                                    return a.handleError(b);
+                                }),
+                                (d.id = b),
+                                document.body.appendChild(d);
+                        } else this.initiate(this);
+                    },
+                },
+                {
+                    key: "render",
+                    value: function render() {
+                        var a = this,
+                            b = this.props,
+                            c = b.style,
+                            d = b.onComplete,
+                            e = b.onSearch,
+                            f = b.alwaysShowEngAddr,
+                            g = b.animation,
+                            h = b.autoClose,
+                            i = b.autoMapping,
+                            j = b.autoResize,
+                            k = b.defaultQuery,
+                            l = b.errorMessage,
+                            m = b.height,
+                            n = b.hideEngBtn,
+                            o = b.hideMapBtn,
+                            p = b.maxSuggestItems,
+                            q = b.pleaseReadGuide,
+                            r = b.pleaseReadGuideTimer,
+                            s = b.scriptUrl,
+                            t = b.shorthand,
+                            u = b.showMoreHName,
+                            v = b.submitMode,
+                            w = b.theme,
+                            x = b.useSuggest,
+                            y = b.width,
+                            z = b.zonecodeOnly,
+                            A = b.focusInput,
+                            B = b.focusContent,
+                            C = _objectWithoutProperties(b, [
+                                "style",
+                                "onComplete",
+                                "onSearch",
+                                "alwaysShowEngAddr",
+                                "animation",
+                                "autoClose",
+                                "autoMapping",
+                                "autoResize",
+                                "defaultQuery",
+                                "errorMessage",
+                                "height",
+                                "hideEngBtn",
+                                "hideMapBtn",
+                                "maxSuggestItems",
+                                "pleaseReadGuide",
+                                "pleaseReadGuideTimer",
+                                "scriptUrl",
+                                "shorthand",
+                                "showMoreHName",
+                                "submitMode",
+                                "theme",
+                                "useSuggest",
+                                "width",
+                                "zonecodeOnly",
+                                "focusInput",
+                                "focusContent",
+                            ]);
+                        return _react2.default.createElement(
+                            "div",
+                            _extends(
+                                {
+                                    ref: function ref(b) {
+                                        a.wrap = b;
+                                    },
+                                    style: _extends(
+                                        {
+                                            width: this.state.width,
+                                            height: this.state.height,
+                                            display: this.state.display,
+                                        },
+                                        c
+                                    ),
+                                },
+                                C
+                            ),
+                            this.state.error && this.props.errorMessage
+                        );
+                    },
+                },
+            ]),
+            b
+        );
+    })(_react2.default.Component);
+(DaumPostcode.propTypes = {
+    onComplete: _propTypes2.default.func.isRequired,
+    onSearch: _propTypes2.default.func,
+    alwaysShowEngAddr: _propTypes2.default.bool,
+    animation: _propTypes2.default.bool,
+    autoClose: _propTypes2.default.bool,
+    autoMapping: _propTypes2.default.bool,
+    autoResize: _propTypes2.default.bool,
+    defaultQuery: _propTypes2.default.string,
+    errorMessage: _propTypes2.default.oneOfType([
+        _propTypes2.default.string,
+        _propTypes2.default.element,
+    ]),
+    height: _propTypes2.default.oneOfType([
+        _propTypes2.default.number,
+        _propTypes2.default.string,
+    ]),
+    hideEngBtn: _propTypes2.default.bool,
+    hideMapBtn: _propTypes2.default.bool,
+    maxSuggestItems: _propTypes2.default.number,
+    pleaseReadGuide: _propTypes2.default.number,
+    pleaseReadGuideTimer: _propTypes2.default.number,
+    scriptUrl: _propTypes2.default.string,
+    shorthand: _propTypes2.default.bool,
+    showMoreHName: _propTypes2.default.bool,
+    style: _propTypes2.default.object,
+    submitMode: _propTypes2.default.bool,
+    theme: _propTypes2.default.object,
+    useSuggest: _propTypes2.default.bool,
+    width: _propTypes2.default.oneOfType([
+        _propTypes2.default.number,
+        _propTypes2.default.string,
+    ]),
+    focusInput: _propTypes2.default.bool,
+    focusContent: _propTypes2.default.bool,
+}),
+    (DaumPostcode.defaultProps = {
+        onSearch: void 0,
+        alwaysShowEngAddr: !1,
+        animation: !1,
+        autoClose: !1,
+        autoMapping: !0,
+        autoResize: !1,
+        defaultQuery: null,
+        errorMessage: defaultErrorMessage,
+        height: 400,
+        hideEngBtn: !1,
+        hideMapBtn: !1,
+        maxSuggestItems: 10,
+        pleaseReadGuide: 0,
+        pleaseReadGuideTimer: 1.5,
+        scriptUrl:
+            "https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js",
+        shorthand: !0,
+        showMoreHName: !1,
+        style: null,
+        submitMode: !0,
+        theme: null,
+        useSuggest: !0,
+        width: "100%",
+        focusInput: !0,
+        focusContent: !0,
+    }),
+    (exports.default = DaumPostcode);


### PR DESCRIPTION
안녕하세요. 저는 신생 스타트업에서 일하고 있는 새내기 개발자 이지은입니다.
먼저, react-daum-postcode 를 만들어주셔서 대단히 감사합니다.
덕분에 react로 웹을 개발하면서 주소를 검색하는 코드를 구현하는데에 있어 굉장히 편리함을 느꼈습니다.

다름이 아니라, 제가 라이브러리를 사용하는데에 있어 발견한 점이 있어 pull request를 생성했습니다.
다름이 아니라, width를 정확한 px가 아닌 90%로 주니
<img width="433" alt="스크린샷 2021-02-12 14 26 43" src="https://user-images.githubusercontent.com/60080273/107733408-56682d80-6d3e-11eb-8bbc-304584c9ec99.png">
다음과 같이 화면이 나타났습니다.
그래서 개발자 도구로 확인을 해보니 DaumPostcode.js 에서 DaumPostcode 안에 있는 b 변수에서 width를 수정해주면 문제가 해결됐습니다. 
이것은 원래처럼 px 값을 줄 경우에도 문제 없이 잘 작동했습니다.

검토해주시면 정말 감사하겠습니다.

설날인데 새해 복 많이 받으세요.
이지은(ee2e@naver.com) 드림