### PR TITLE
Fix height to work even if height is specified as %

### DIFF
--- a/src/DaumPostcode.jsx
+++ b/src/DaumPostcode.jsx
@@ -43,7 +43,7 @@ class DaumPostcode extends React.Component {
         animation: comp.props.animation,
         autoMapping: comp.props.autoMapping,
         autoResize: comp.props.autoResize,
-        height: comp.props.height,
+        height: '100%',
         hideEngBtn: comp.props.hideEngBtn,
         hideMapBtn: comp.props.hideMapBtn,
         maxSuggestItems: comp.props.maxSuggestItems,


### PR DESCRIPTION
안녕하세요, 라이브러리 잘 사용하고 있습니다. 덕분에 서비스에 편하게 적용할 수 있었습니다.
높이와 관련된 이슈를 발견하여, PR 올립니다.

우선, height 를 퍼센트로 줄 때, wrapper element 와 postcode에 모두 퍼센트로 전달되어, 정상적으로 반영되지 않는 케이스가 있습니다.
```html
<div id='root' style={{height: 700}}>
   <DaumPostCode 
       ...
       height='50%'
   />
</div>
```
위와 같은 코드에서, root element의 50%를 wrapper 가 가지게 되고, postcode는 wrapper 의 50%를 가지게 되어, 원했던 350px 이 아닌 175px 영역에만 표출됩니다. #21 과 동일한 이슈로 보여집니다.

다음으로, autoResize를 설정해도, 검색 결과에 따른 높이 변화가 제대로 반영이 되지 않고 있습니다. 내부에서 onresize 이벤트를 통해 변경되는 height 는 wrapper element 에만 적용되고 있기 때문인 것 같습니다.

![스크린샷 2021-03-14 오후 4 46 38](https://user-images.githubusercontent.com/24601577/111061093-dc65c880-84e4-11eb-9d43-631419678553.png)
위 사진은 autoResize 를 설정한 상태에서 검색한 시점의 DOM 입니다. wrapper element에 높이가 반영되어 영역을 차지하고 있지만, daum_layer 에는 반영되지 않습니다. 이로 인해 높이의 차이만큼 빈 영역이 생기고 있습니다.

두 이슈 모두 생성자 옵션에 `height: '100%'` 를 주어, wrapper element 의 높이를 따라가게 하면 해결할 수 있을거라 생각합니다. 공식 문서에서도 가변적인 높이에 대해 onresize 를 사용할 때, 생성자 옵션에 `height: '100%'` 를 전달하고 있습니다.