### PR TITLE
Add package.json files field instead of .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-example
-.babelrc
-.eslint*
-.idea
-.npmignore
-webpack.*

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "React daum-postcode component",
   "main": "./lib/index.js",
   "types": "./index.d.ts",
+  "files": [
+    "lib",
+    "index.d.ts"
+  ],
   "scripts": {
     "build": "babel src -d lib",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
안녕하세요! 현재 해당 패키지를 프로젝트에 설치할 때, `src` 디랙토리까지 포힘되고 있습니다.

`.npmignore` 에 추가하려 했는데, 포함시키지 않을 파일을 관리하는것 보단, `package.json` 의 `files` 필드를 통하여 포함시킬 파일만 관리하는게 어떨까 하여 PR 올립니다.

[package.json files field doc](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files)