### PR TITLE
Improve dynamic loading of script

### DIFF
--- a/src/DaumPostcode.tsx
+++ b/src/DaumPostcode.tsx
@@ -1,5 +1,5 @@
 import React, { Component, createRef, CSSProperties } from 'react';
-import loadPostcode, { PostcodeOptions } from './loadPostcode';
+import loadPostcode, { PostcodeConstructor, PostcodeOptions } from './loadPostcode';
 
 export interface DaumPostcodeProps extends Omit<PostcodeOptions, 'oncomplete' | 'onresize' | 'onclose' | 'onsearch'> {
   onComplete?: PostcodeOptions['oncomplete'];
@@ -48,7 +48,7 @@ class DaumPostcode extends Component<DaumPostcodeProps, State> {
     loadPostcode(scriptUrl).then(initiate).catch(onError);
   }
 
-  initiate = (Postcode: typeof window.daum.Postcode) => {
+  initiate = (Postcode: PostcodeConstructor) => {
     if (!this.wrap.current) return;
     const {
       scriptUrl,

--- a/src/DaumPostcode.tsx
+++ b/src/DaumPostcode.tsx
@@ -82,7 +82,8 @@ class DaumPostcode extends Component<DaumPostcodeProps, State> {
     postcode.embed(this.wrap.current, { q: defaultQuery, autoClose: autoClose });
   };
 
-  onError = () => {
+  onError = (e: unknown) => {
+    console.error(e);
     this.setState({ hasError: true });
   };
 

--- a/src/loadPostcode.ts
+++ b/src/loadPostcode.ts
@@ -121,11 +121,12 @@ export interface Postcode {
 
 const loadPostcode = (function () {
   const scriptId = 'daum_postcode_script';
-  return function (url: string): Promise<typeof window.daum.Postcode> {
-    const isScriptExist = !!document.getElementById(scriptId);
-    if (isScriptExist) return Promise.resolve(window.daum.Postcode);
+  let promise: Promise<typeof window.daum.Postcode> | null = null;
 
-    return new Promise((resolve, reject) => {
+  return function (url: string): Promise<typeof window.daum.Postcode> {
+    if( promise ) return promise;
+
+    promise = new Promise((resolve, reject) => {
       const script = document.createElement('script');
       script.src = url;
       script.onload = () => {
@@ -138,7 +139,9 @@ const loadPostcode = (function () {
       script.onerror = (error) => reject(error);
       script.id = scriptId;
       document.body.appendChild(script);
-    });
+    })
+
+    return promise;
   };
 })();
 

--- a/src/loadPostcode.ts
+++ b/src/loadPostcode.ts
@@ -1,14 +1,12 @@
 declare global {
   interface Window {
-    daum: {
-      postcode: {
+    daum?: {
+      postcode?: {
         load: (fn: () => void) => void;
         version: string;
         _validParam_: boolean;
       };
-      Postcode: {
-        new (postcodeOptions: PostcodeOptions): Postcode;
-      };
+      Postcode?: PostcodeConstructor;
     };
   }
 }
@@ -114,6 +112,10 @@ export interface EmbedOptions {
   autoClose?: boolean;
 }
 
+export interface PostcodeConstructor {
+  new (postcodeOptions: PostcodeOptions): Postcode;
+}
+
 export interface Postcode {
   open(openOptions?: OpenOptions): void;
   embed(element: HTMLElement, embedOptions?: EmbedOptions): void;
@@ -121,20 +123,19 @@ export interface Postcode {
 
 const loadPostcode = (function () {
   const scriptId = 'daum_postcode_script';
-  let promise: Promise<typeof window.daum.Postcode> | null = null;
+  let promise: Promise<PostcodeConstructor> | null = null;
 
-  return function (url: string): Promise<typeof window.daum.Postcode> {
+  return function (url: string): Promise<PostcodeConstructor> {
     if( promise ) return promise;
 
     promise = new Promise((resolve, reject) => {
       const script = document.createElement('script');
       script.src = url;
       script.onload = () => {
-        try {
-          resolve(window.daum.Postcode);
-        } catch (e) {
-          reject(e);
+        if( window?.daum?.Postcode ) {
+          return resolve(window.daum.Postcode);
         }
+        reject(new Error('Script is loaded successfully, but cannot find Postcode module. Check your scriptURL property.'))
       };
       script.onerror = (error) => reject(error);
       script.id = scriptId;


### PR DESCRIPTION
# TODO
- [ ] ~~promise 가 rejected 되었다면, 다음 요청 시 다시 로드 하도록 수정~~
   - next features

---

- 스크립트 동적 로딩에 대한 핸들링을 단일 프로미스로 사용하도록 수정
- 컴포넌트 랜더링 과정에서 오류 발생 시 console.error 출력
- 전역변수의 Postcode 관련 타입을 옵셔널하게 변경
- See https://github.com/bernard-kms/react-daum-postcode/issues/46